### PR TITLE
Reference captured `config` instead of reading from `this`

### DIFF
--- a/dist/hasl-departure-card.js
+++ b/dist/hasl-departure-card.js
@@ -226,7 +226,7 @@ class HASLDepartureCard extends HTMLElement {
 
                     // Updated
                     if (config.updated === true) {
-                        if (this.config.updated_minutes==0 || this.config.updated_minutes < minutesSinceUpdate ) {
+                        if (config.updated_minutes==0 || config.updated_minutes < minutesSinceUpdate ) {
                             html += `<table><tr>
                                     <td class="last-update"><sub><i>${lang[culture].last_updated} ${updatedValue}</i></sub></td>
                                 </tr></table>`;


### PR DESCRIPTION
Bugfix, addresses https://github.com/hasl-sensor/lovelace-hasl-departure-card/issues/19

Perhaps there's some other source somewhere which should get this fix, but perhaps this can serve as a conveniently available temporary patch of the "official" card anyway.
 
Works on my machine™

